### PR TITLE
Fixed a compiling issue

### DIFF
--- a/src/mmwave/model/mmwave-flex-tti-mac-scheduler.h
+++ b/src/mmwave/model/mmwave-flex-tti-mac-scheduler.h
@@ -353,8 +353,8 @@ namespace ns3 {
 	/*
 	 * Out-of-band backhaul pre-computed optimal scheduling result.
 	 */
-	uint32_t m_symAvilStart;  // the first available symbol index in one subframe.  
-	uint32_t m_symAvilEnd;    // the last available symbol index in one subframe.
+	uint32_t m_symAvailStart;  // the first available symbol index in one subframe.  
+	uint32_t m_symAvailEnd;    // the last available symbol index in one subframe.
     };
 
 }


### PR DESCRIPTION
Fixed the variable name _m_symAvailStart_ and _m_symAvailEnd_ in _src/mmwave/model/mmwave-flex-tti-mac-scheduler.h_
(line 356 and 357, missing a letter)